### PR TITLE
Add nbgitpuller link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # jupyter-in-geol-classroom
 Demo for GEOL faculty on some ways to use Jupyter notebooks in the classroom
+
+To run the Jupyter Notebook from this repository on the CSDMS JupyterHub,
+click [this link](https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fgregtucker%2Fjupyter-in-geol-classroom&urlpath=tree%2Fjupyter-in-geol-classroom%2Fjupyter_in_classroom.ipynb&branch=master).
+You'll be prompted to login to the Hub,
+and the Notebook will start there.


### PR DESCRIPTION
This PR adds a link that, when clicked by a user, clones this repo to the CSDMS JupyterHub and loads the Notebook. The user will be prompted to login if they aren't currently.

I've tested it with a non-admin account on the Hub.